### PR TITLE
Allow npm to listen to connections from outside localhost.

### DIFF
--- a/webpack/dev-server.js
+++ b/webpack/dev-server.js
@@ -12,7 +12,7 @@ var config = require('./dev.config');
 var compiler = webpack(config.webpack);
 var devServer = new WebpackDevServer(compiler, config.server.options);
 
-devServer.listen(config.server.port, 'localhost', function () {
+devServer.listen(config.server.port, '0.0.0.0', function () {
   debug('webpack-dev-server listening on port %s', config.server.port);
 });
 


### PR DESCRIPTION
This is necessary when accessing the webserver (running on a Docker container)
from the host system.
