### PR TITLE
Fix parse_document to parse file from command line filename arg.

### DIFF
--- a/data/parse_document.py
+++ b/data/parse_document.py
@@ -412,13 +412,13 @@ if __name__ == '__main__':
     }
 
     outfile = os.path.join(OUTPUT_FOLDER, "articles.json")
+    data = []
     if len(sys.argv) > 1:
-        data = []
         file_path = sys.argv[1]
         file_name, ext = os.path.splitext(os.path.basename(file_path))
         outfile = os.path.join(OUTPUT_FOLDER, os.path.basename(file_name) + ".json")
         try:
-            data.append(parse_document(file_path))
+            data.append(parse_document(os.path.abspath(file_path), os.path.basename(file_path)))
         except ArticleParseError as e:
             print e
     else:


### PR DESCRIPTION
_What_
Restore functionality that allows:
mkdir -p data/DocumentsParsed/
python data/parse_document.py data/sample/article/somearticle.txt
cat data/DocumentsParsed/somearticle.json

_How_
Updated call to parsing function in command line processing to pass two parameters.

_Why_
Much easier debugging of document parsing.