### PR TITLE
Highlights Supported by Deciding Force Parser 

### DIFF
--- a/data/parse_document.py
+++ b/data/parse_document.py
@@ -97,9 +97,6 @@ def parse_article(raw_text, filename):
         raise ArticleParseError("Only found Useless tuas!",
                                 ArticleParseError.DUPLICATE_ERROR)
 
-    #print(clean_text)
-    # Warning: brackets left over are usually bad news.
-
     #Trace highlights
     index = 0
     highlight_open = False
@@ -111,7 +108,7 @@ def parse_article(raw_text, filename):
         if (clean_text[index] == "[" and highlight_open):
             raise Exception("Extra [ in " + filename + " article number " + article_number + "\n")
 
-        #Assume that right square bracket with its corresponding left square bracket is an error.
+        #Assume that right square bracket without its corresponding left square bracket is an error.
         elif (clean_text[index] == "]" and not highlight_open):
             raise Exception("Extra ] in " + filename + " article number " + article_number + "\n")
 
@@ -140,10 +137,6 @@ def parse_article(raw_text, filename):
             raise Exception("Highlight '" + text + "' not recognized in " + filename + "\n")
         end_index = start_index + text_length
         offsets.append([start_index, end_index])
-
-
-    #1. make error type in pybossa_api.py
-    #2. try/catch in load_data.py (where parse_document is used)
 
     #Can I delete below the comments below?
     #if '[' in clean_text or ']' in clean_text:

--- a/data/parse_document.py
+++ b/data/parse_document.py
@@ -446,7 +446,7 @@ def parse_documents(directory_path, error_directory_paths):
 if __name__ == '__main__':
     DATA_FOLDER = os.path.dirname(os.path.abspath(__file__))
     ARTICLE_FOLDER = os.path.join(DATA_FOLDER, "sample/articles")
-    OUTPUT_FOLDER = os.path.join(DATA_FOLDER, "DocumentsParsed/all_articles")
+    OUTPUT_FOLDER = os.path.join(DATA_FOLDER, "DocumentsParsed")
     FILENAME_ERROR_FOLDER = os.path.join(DATA_FOLDER, "DocumentErrors/filename")
     HEADER_ERROR_FOLDER = os.path.join(DATA_FOLDER, "DocumentErrors/header")
     TEXT_ERROR_FOLDER = os.path.join(DATA_FOLDER, "DocumentErrors/text")
@@ -462,13 +462,13 @@ if __name__ == '__main__':
     }
 
     outfile = os.path.join(OUTPUT_FOLDER, "articles.json")
-    data = []
     if len(sys.argv) > 1:
+        data = []
         file_path = sys.argv[1]
         file_name, ext = os.path.splitext(os.path.basename(file_path))
         outfile = os.path.join(OUTPUT_FOLDER, os.path.basename(file_name) + ".json")
         try:
-            data.append(parse_document(os.path.abspath(file_path), os.path.basename(file_path)))
+            data.append(parse_document(file_path))
         except ArticleParseError as e:
             print e
     else:

--- a/data/parse_document.py
+++ b/data/parse_document.py
@@ -412,13 +412,13 @@ if __name__ == '__main__':
     }
 
     outfile = os.path.join(OUTPUT_FOLDER, "articles.json")
+    data = []
     if len(sys.argv) > 1:
-        data = []
         file_path = sys.argv[1]
         file_name, ext = os.path.splitext(os.path.basename(file_path))
         outfile = os.path.join(OUTPUT_FOLDER, os.path.basename(file_name) + ".json")
         try:
-            data.append(parse_document(file_path))
+            data.append(parse_document(os.path.abspath(file_path), os.path.basename(file_path)))
         except ArticleParseError as e:
             print e
     else:

--- a/data/pybossa_api.py
+++ b/data/pybossa_api.py
@@ -36,6 +36,9 @@ class ImproperConfigForRemote(Exception):
 class InvalidTaskRun(Exception):
     pass
 
+class DecidingForceParserError(Exception):
+    pass
+
 @django_rq.job('task_exporter', timeout=60, result_ttl=24*3600)
 def create_or_update_remote_project_worker(project_id,
                                            debug_presenter=False,


### PR DESCRIPTION
_What_  
Previously the Deciding Force parser was unable to handle highlights/square brackets. With these additions the parser now removes highlights from the text, records the highlight offsets in the article metadata, and throws errors if improperly formatted highlights or square brackets are found in the text. 

_How_
I iterated through the text file to find "[" and "]" characters, signifying the start and end of a highlight. If a left bracket was found without its corresponding right bracket or vice versa an error is thrown. When a highlight has been closed by a left and right square bracket the highlight is stored and removed from the text. In a final step the highlight text is compared to the article to find its starting index offset. At this stage all the highlight offsets are calculated. 

_Why_
Handle highlights in Deciding Force articles. 

_Comments_
- I added a new class of exceptions in pybossa_api.py but when I tried to import it to parse_document.py an error was raised about pybossa_api.py needing django to be imported. I want to clarify at this stage whether I should add the dependencies for pybossa_api.py or stick with vanilla exceptions. 
- Also I'm aware that this branch is behind master by quite a bit but looking at the diff it doesn't look like it matters.
- Can I delete the previous code that was commented out?  

